### PR TITLE
[M3C-12] OutOfBounds and P+N+1

### DIFF
--- a/include/m3c/asm/tokenizer.h
+++ b/include/m3c/asm/tokenizer.h
@@ -12,17 +12,12 @@
 typedef struct tagM3C_ASM_SourceBuffer {
     /**
      * \brief A pointer to the first byte of the buffer.
-     *
-     * \warning If the buffer length is `0`, then it can point anywhere. The buffer length is
-     * considered to be zero if the #last field is less than this field.
-     * \warning The buffer length must be less than `2 ** 32 - 1`.
      */
     const m3c_u8 *first;
     /**
      * \brief A pointer to the last byte in the buffer.
      *
-     * \warning If the buffer length is `0`, then it can point anywhere. The buffer length is
-     * considered to be zero if this field is less than the #first field.
+     * \warning If the buffer length is `0`, then it must be `NULL`.
      * \warning The buffer length must be less than `2 ** 32 - 1`.
      */
     const m3c_u8 *last;

--- a/include/m3c/asm/tokenizer.h
+++ b/include/m3c/asm/tokenizer.h
@@ -161,6 +161,12 @@ typedef struct tagM3C_ASM_TokenizerOptions {
  * \brief Breaks the source code into tokens and pushes them into \ref M3C_ASM_Tokenizer::tokens
  * "tokens".
  *
+ * \warning The current implementation assumes that \ref M3C_ASM_Tokenizer::src "src" contains a
+ * byte array object, which means that the addition operation, which results in a pointer that
+ * points to the element immediately after this array, did not lead to an overflow. For example, see
+ * N1570 $6.5.6 "Additive operators" clause 8. However, С89 just states that such expression does
+ * not lead to undefined behavior.
+ *
  * \param[in,out] tokenizer tokenizer
  * \param[in]     options   options
  * \return

--- a/include/m3c/asm/tokenizer.h
+++ b/include/m3c/asm/tokenizer.h
@@ -144,11 +144,13 @@ typedef struct tagM3C_ASM_TokenizerOptions {
      * "vector of tokens" if it runs out of space.
      *
      * \details If it returns a pointer to zero, parsing will fail with an #M3C_ASM_ERROR_OOM error.
-     * If set as a `NULL`, no call is made and #M3C_ASM_ERROR_OOM will return immediately.
+     * If set as a `NULL`, no call is made and #M3C_ASM_ERROR_OOM will return immediately after the
+     * \ref M3C_ASM_Tokenizer::tokens "vector of tokens" runs out of space.
      *
      * \note Requests twice as much memory as before. However, the maximum requested memory size is
      * for the number of tokens equal to the length of the source code (one character - one token)
-     * `+ 1`.
+     * plus one for #M3C_ASM_EOF_TOKEN. In fact it always requests for `newCap+1` to match the
+     * `P+N+1` rule.
      *
      * \warning Can be `NULL`.
      */

--- a/src/asm/tokenizer.c
+++ b/src/asm/tokenizer.c
@@ -67,7 +67,7 @@ m3c_bool __M3C_ASM_does_match(const m3c_u8 ranges[][2], m3c_u32 n, m3c_u8 ch) {
 M3C_ASM_Error __M3C_ASM_push_token(
     M3C_ASM_Tokenizer *tokenizer, const M3C_ASM_TokenizerOptions *options, M3C_ASM_Token *token
 ) {
-    m3c_u32 newCap;
+    m3c_u32 newCapPlusOne;
     void *newPtr;
     token->len = (m3c_u32)(tokenizer->ptr - token->ptr);
 
@@ -76,16 +76,21 @@ M3C_ASM_Error __M3C_ASM_push_token(
             return M3C_ASM_ERROR_OOM;
 
         /* There is no reason to ask for more than the number of characters in src + 1. */
-        newCap = m3c_min(
-            m3c_max(1, (m3c_u32)(tokenizer->src.last - tokenizer->src.first)),
-            tokenizer->tokens->cap + tokenizer->tokens->cap
+        newCapPlusOne = m3c_min(
+            m3c_max(
+                2 /* M3C_ASM_EOF_TOKEN and `P+N+1` rule */,
+                (m3c_u32)(tokenizer->src.last - tokenizer->src.first) +
+                    2 /* M3C_ASM_EOF_TOKEN and `P+N+1` rule */
+            ),
+            tokenizer->tokens->cap + tokenizer->tokens->cap + 1 /* `P+N+1` rule */
         );
-        newPtr = options->tokens_realloc(tokenizer->tokens->data, sizeof(M3C_ASM_Token) * newCap);
+        newPtr =
+            options->tokens_realloc(tokenizer->tokens->data, sizeof(M3C_ASM_Token) * newCapPlusOne);
         if (!newPtr)
             return M3C_ASM_ERROR_OOM;
 
         tokenizer->tokens->data = newPtr;
-        tokenizer->tokens->cap = newCap;
+        tokenizer->tokens->cap = newCapPlusOne - 1;
     }
 
     tokenizer->tokens->data[tokenizer->tokens->len++] = *token;


### PR DESCRIPTION
Everyone seems to rely on the `P+N+1` rule, but ignore it when allocating. Indeed, there seems to be only a small chance that the allocator will return a region of memory just before the end of the memory (physical or segment).

And it seems that C89 does not have this rule at all. It only requires that the behavior be defined in such a case.