### PR TITLE
[M3C-62] impl Line Splitting Phase

### DIFF
--- a/include/m3c/asm/preproc.h
+++ b/include/m3c/asm/preproc.h
@@ -7,6 +7,99 @@
 #include <m3c/asm/types.h>
 #include <m3c/core/diagnostics.h>
 
+/** \file
+ * Preprocessor routines.
+ *
+ * \section term Terminology:
+ *
+ * \subsection term_eol End of line sequence
+ * <b>E</b>nd <b>o</b>f <b>l</b>ine (or <b>e</b>nd-<b>o</b>f-<b>l</b>ine, EOL) sequence - is a
+ * sequence of characters that indicates the end of a line.
+ *
+ *
+ * Only the following sequences are considered as end-of-line sequences:
+ * + `"\n"`
+ * + `"\r"`
+ * + `"\r\n"`
+ *
+ * \sa \ref term_phase_ls
+ *
+ * \subsection term_lcc Line continuation character
+ * The backslash character (<tt>'\\\\'</tt>), when placed immediately before the \ref term_eol
+ * "end of line sequence" sequence, forms a \ref term_lcs "line continuation sequence".
+ *
+ * \subsection term_lcs Line continuation sequence
+ * A sequence of characters that is recognized by the preprocessor as a continuation of a \ref
+ * term_logical_line "logical line". If the preprocessor is used these sequences is simply removed
+ * from the source code during \ref term_phase_ls "Line Splitting Phase", lengthening \ref
+ * term_logical_line "logical lines".
+ *
+ *
+ * Line continuation sequences (<tt>'\\\\'</tt> is used as \ref term_lcc
+ * "line continuation character"):
+ * + `"\\\n"`
+ * + `"\\\r"`
+ * + `"\\\r\n"`
+ *
+ * \sa \ref term_eol
+ *
+ * \subsection term_phase_ls Line Splitting Phase
+ * If a preprocessor is used, the document is split into \ref term_logical_line "logical lines"
+ * during this phase by removing \ref term_lcs "line continuation sequences" from the source code.
+ * If a preprocessor is not used, \ref term_physical_line "physical lines" correspond strictly to
+ * \ref term_logical_line "logical lines".
+ *
+ * For example, in this phase, a document containing a sequence of characters `"0\\\r\n1\r\n2\\"`
+ * will be split into the following \ref term_logical_line "logical lines":
+ * + (without preprocessor) `"0\\\r\n"`, `"1\r\n"`, `"2\\"`
+ * + (with preprocessor) `"01\r\n"`, `"2\\"`
+ *
+ * \subsubsection term_phase_ls_id Implementation details:
+ * Actually, this phase does not split the document into \ref term_logical_line "logical lines", but
+ * into \ref M3C_ASM_Fragment "fragments". For example, a document containing a sequence of
+ * characters `"0\\\r\n1\r\n2\\"` will be split into the following \ref M3C_ASM_Fragment
+ * "fragments":
+ * + (without preprocessor) `"0\\\r\n"`, `"1\r\n"`, `"2\\"`
+ * + (with preprocessor) `"0"`, `"1\r\n"`, `"2\\"`
+ *
+ * \note In other words, each fragment corresponds to a \ref term_physical_line "physical line",
+ * except when the preprocessor is used and the \ref term_physical_line "physical line" ends with
+ * the \ref term_lcs "line continuation sequence", in which case the end of the fragment containing
+ * this \ref term_lcs "line continuation sequence" is truncated.
+ *
+ * \sa \ref term_phase
+ *
+ * \subsection term_logical_line Logical line
+ * A sequence of characters that ends with either an \ref term_eol "end of line sequence" or the end
+ * of file (EOF). If a preprocessor is used, it may be formed from several \ref term_physical_line
+ * "physical lines" during \ref term_phase_ls "Line Splitting Phase". However, if no preprocessor is
+ * used, it corresponds exactly to one \ref term_physical_line "physical line".
+ *
+ * \sa \ref term_logical_pos
+ *
+ * \subsection term_logical_pos Logical position
+ * Contains zero-based \ref term_logical_line "logical line" index and zero-based character index.
+ *
+ * \sa \ref term_phase_ls, \ref term_physical_pos
+ *
+ * \subsection term_physical_line Physical line
+ * A sequence of characters in a document that ends with either an \ref term_eol
+ * "end of line sequence" or the end of file (EOF).
+ *
+ * \sa \ref term_physical_pos, \ref term_logical_line
+ *
+ * \subsection term_physical_pos Physical position
+ * The physical (real) position of a character in a (raw) document. Contains zero-based
+ * \ref term_physical_line "physical line" index and zero-based character index.
+ *
+ * \sa \ref term_phase_ls, \ref term_logical_pos
+ *
+ * \subsection term_phase Phase
+ *
+ * Known phases:
+ * + \ref term_phase_ls
+ */
+
 /**
  * \brief Fragment.
  */
@@ -16,12 +109,15 @@ typedef struct __tagM3C_ASM_Fragment {
      */
     m3c_u8 const *bFirst;
     /**
-     * \brief Pointer to the last byte of this fragment (or `NULL` if this document has a length
+     * \brief Pointer to the last byte of this fragment (or `NULL` if this fragment has a length
      * equal to `0`).
      */
     m3c_u8 const *bLast;
     /**
-     * \brief Position of the first character in this fragment.
+     * \brief \ref term_physical_pos "Physical position" of the first character in this
+     * fragment.
+     *
+     * \note \ref M3C_ASM_Position::character "pos::character" will be always equal to zero.
      */
     M3C_ASM_Position pos;
 } M3C_ASM_Fragment;
@@ -43,6 +139,8 @@ typedef struct __tagM3C_ASM_FragmentsCache {
 struct __tagM3C_ASM_Document {
     /**
      * \brief Pointer to the first byte of this document.
+     *
+     * \warning Can't be `NULL` even if the document is empty.
      */
     m3c_u8 const *bFirst;
     /**
@@ -53,10 +151,11 @@ struct __tagM3C_ASM_Document {
     /**
      * \brief Document fragments.
      *
-     * \details If a preprocessor is used, these are the fragments after Continuation Line
-     * Collapsing phase. If no preprocessor is used, then only one fragment is stored here, which
-     * contains the whole document.
+     * \details This field will be filled in during \ref term_phase_ls "Line Splitting Phase".
      *
+     * \note To access a specific physical line fragment, use the index of the \ref
+     * term_physical_line "physical line". However, if a preprocessor is used, the \ref term_lcs
+     * "line continuation sequence" will be missing in the fragment.
      * \note The fragments will be the same for the same document. There is no need to calculate
      * them each time the same document is included.
      */
@@ -126,21 +225,20 @@ struct __tagM3C_ASM_PreProc {
 };
 
 /**
- * \brief Performs the continuation line collapsing phase of the preprocessor, filling the document
- * \ref M3C_ASM_Document::fragments "fragments".
+ * \brief Performs \ref term_phase_ls "Line Splitting Phase".
  *
- * \details Handled sequences:
- * + `\\\n`
- * + `\\\r\n`
- * + `\\\r`
+ * \details Splits the document into lines (using \ref term_eol "EOL" sequences), filling the
+ * document \ref M3C_ASM_Document::fragments "fragments". If a preprocessor (param `usePreproc`) is
+ * used, \ref term_lcs "line continuation sequences" are cut from the fragments.
  *
- * \warning Overwrites fragments without regard to what is there, which can lead to memory leak.
+ * \note If the fragments are already filled, returns \ref M3C_ERROR_OK "OK" and does nothing.
  *
- * \param document document
+ * \param[in,out] document   document
+ * \param         usePreproc
  * \return
  * + #M3C_ERROR_OK
- * + #M3C_ERROR_OOM - when the function lacks memory
+ * + #M3C_ERROR_OOM - if the function lacks memory
  */
-M3C_ERROR __M3C_ASM_Document_ContinuationLineCollapsingPhase(M3C_ASM_Document *document);
+M3C_ERROR __M3C_ASM_Document_SplitLines(M3C_ASM_Document *document, m3c_bool usePreproc);
 
 #endif /* _M3C_INCGUARD_ASM_PREPROC_H */

--- a/include/m3c/common/utf8.h
+++ b/include/m3c/common/utf8.h
@@ -35,6 +35,11 @@ typedef m3c_u8 M3C_UTF8cu;
 #define M3C_UTF8_REPLACEMENT_CHARACTER_BLEN 3
 
 /**
+ * \brief Maximum number of bytes a character can occupy in UTF-8.
+ */
+#define M3C_UTF8_CP_MAX_BLEN 4
+
+/**
  * \see #M3C_UTF8ValidateCodepoint
  */
 #define M3C_UTF8_OK 0
@@ -97,6 +102,28 @@ M3C_ERROR M3C_UTF8GetASCIICodepointWithLen(
  */
 M3C_ERROR
 M3C_UTF8ReadCodepointWithLen(const m3c_u8 *ptr, const m3c_u8 *last, M3C_UCP *cp, m3c_size_t *len);
+
+/**
+ * \brief Reads the previous code point in the buffer. If the pointer does not point to the first
+ * byte of the code point, it will read that code point.
+ *
+ * \param[in]  ptr   a pointer
+ * \param[in]  first a pointer to first code unit in buffer
+ * \param[in]  last  a pointer to the last code unit in the buffer or, if the buffer is empty, to
+ * something with an address lesser than `ptr`. Can be `NULL`
+ * \param[out] cp    writes here decoded code point
+ * \param[out] delta writes here the delta between `ptr` and the pointer to the first code unit of
+ * read code point
+ * \return
+ * + #M3C_ERROR_OK
+ * + #M3C_ERROR_EOF - if there are not previous code points in the buffer
+ * + #M3C_ERROR_INVALID_ENCODING - in this case, the code point of `�` is written to `cp` and the
+ * length of the maximal subpart of an ill-formed subsequence is written to `len`
+ */
+M3C_ERROR
+M3C_UTF8ReadBackCodepointWithLen(
+    const m3c_u8 *ptr, const m3c_u8 *first, const m3c_u8 *last, M3C_UCP *cp, m3c_size_t *delta
+);
 
 /**
  * \brief Writes the specified code point to the buffer.

--- a/src/asm/lex.c
+++ b/src/asm/lex.c
@@ -1450,7 +1450,7 @@ M3C_ERROR __M3C_ASM_lexNextToken(M3C_ASM_Lexer *lexer) {
     M3C_LOOP {
         PEEK;
         if (status == M3C_ERROR_EOF)
-            return status;
+            return M3C_ERROR_EOF;
 
         if (cp != ' ' && cp != '\t')
             break;
@@ -1474,9 +1474,7 @@ M3C_ERROR __M3C_ASM_lexNextToken(M3C_ASM_Lexer *lexer) {
         } else {
             __ADVANCE_ONLY_POS_NL;
             TOK_END;
-            if (TOK_PUSH != M3C_ERROR_OK)
-                return M3C_ERROR_OOM;
-            return status;
+            return TOK_PUSH;
         }
     } else if (cp == '!') {
         ADVANCE;

--- a/src/asm/preproc.c
+++ b/src/asm/preproc.c
@@ -2,105 +2,109 @@
 
 #include <m3c/common/coltypes.h>
 #include <m3c/common/utf8.h>
+#include <m3c/common/macros.h>
 #include <m3c/rt/alloc.h>
 
-M3C_ERROR __M3C_ASM_Document_ContinuationLineCollapsingPhase(M3C_ASM_Document *document) {
+M3C_ERROR __M3C_ASM_Document_SplitLines(M3C_ASM_Document *document, m3c_bool usePreproc) {
     typedef M3C_VEC(M3C_ASM_Fragment) M3C_ASM_Fragments;
+
+    M3C_UCP cp;
     M3C_ASM_Fragments vec;
     M3C_ASM_Fragment *fragment;
     M3C_ASM_Fragment newFragment;
-    M3C_ASM_Position pos = {0, 0};
-    m3c_u8 const *ptr;
-    m3c_size_t x;
 
-    /* init vec */
-    /* LATER: do we assume that line continuation is a very rarely used feature? Why use 2 as
-     * capacity? */
+    m3c_u8 const *ptr0;
+    m3c_u8 const *nextFragmentPtr;
+
+    m3c_size_t cpLen0;
+    m3c_size_t cpLen1;
+    m3c_size_t cpLenB;
+
+    M3C_ASM_Position pos = {0, 0};
+
+    if (document->fragments.len)
+        return M3C_ERROR_OK;
+
     vec.data = (M3C_ASM_Fragment *)m3c_malloc(sizeof(M3C_ASM_Fragment) * 2);
     if (!vec.data)
         return M3C_ERROR_OOM;
     vec.cap = 2;
-    vec.len = 1;
+    vec.len = 0;
 
     /* init first fragment */
-    vec.data->bFirst = document->bFirst;
-    vec.data->bLast = document->bLast;
-    vec.data->pos = pos;
+    vec.len = 1;
+    fragment = &vec.data[0];
+    fragment->bFirst = document->bFirst;
+    fragment->bLast = document->bLast;
+    fragment->pos = pos;
 
-    ptr = document->bFirst;
+    ptr0 = document->bFirst;
 
-    /* NOTE: if the document is empty, `document->bLast` will be `NULL` */
-    while (ptr <= document->bLast) {
-        if (*ptr == '\n') {
-            fragment = &vec.data[vec.len - 1];
+    M3C_LOOP {
 
-            if (ptr - fragment->bFirst >= 1 && ptr[-1] == '\\') {
-                /* '\\\n' */
+        if (M3C_UTF8ReadCodepointWithLen(ptr0, fragment->bLast, &cp, &cpLen0) == M3C_ERROR_EOF)
+            break;
 
-                x = 2;
-                goto lc;
+        if (cp == '\r') {
 
-            } else if (ptr - fragment->bFirst >= 2 && ptr[-1] == '\r' && ptr[-2] == '\\') {
-                /* '\\\r\n' */
+            if (M3C_UTF8ReadCodepointWithLen(ptr0 + cpLen0, fragment->bLast, &cp, &cpLen1) ==
+                    M3C_ERROR_OK &&
+                cp == '\n')
+                nextFragmentPtr = ptr0 + cpLen0 + cpLen1;
+            else
+                nextFragmentPtr = ptr0 + cpLen0;
 
-                x = 3;
-                goto lc;
+            if (usePreproc && (M3C_UTF8ReadBackCodepointWithLen(
+                                   ptr0, fragment->bFirst, fragment->bLast, &cp, &cpLenB
+                               ) == M3C_ERROR_OK &&
+                               cp == '\\')) {
+                fragment->bLast = ptr0 - cpLenB == fragment->bFirst ? M3C_NULL : ptr0 - cpLenB - 1;
+            } else
+                fragment->bLast = nextFragmentPtr - 1;
 
+            goto cut;
+
+        } else if (cp == '\n') {
+
+            nextFragmentPtr = ptr0 + cpLen0;
+
+            if (usePreproc &&
+                M3C_UTF8ReadBackCodepointWithLen(
+                    ptr0, fragment->bFirst, fragment->bLast, &cp, &cpLenB
+                ) == M3C_ERROR_OK &&
+                cp == '\\') {
+                fragment->bLast = ptr0 - cpLenB == fragment->bFirst ? M3C_NULL : ptr0 - cpLenB - 1;
             } else {
-                /* just '\n` or '\r\n' */
-                ++ptr;
-                ++pos.line;
-                pos.character = 0;
+                fragment->bLast = nextFragmentPtr - 1;
             }
-        } else if (*ptr == '\r') {
-            fragment = &vec.data[vec.len - 1];
 
-            if (fragment->bLast - ptr >= 1 && ptr[1] == '\n') {
-                /* it's * ~ \r ~ \n and we will handle it in `\n` branch. Now just advance */
-
-                ++ptr;
-                ++pos.character;
-                continue;
-            } else if (ptr - fragment->bFirst >= 1 && ptr[-1] == '\\') {
-                /* '\\\r' */
-
-                x = 2;
-                goto lc;
-            } else {
-                /* just '\r` */
-                ++ptr;
-                ++pos.line;
-                pos.character = 0;
-            }
-        } else {
-            /* not `\n` or `\r` but can by multibyte */
-            M3C_UTF8ValidateCodepoint(&ptr, document->bLast);
-            ++pos.character;
+            goto cut;
         }
+
+        ptr0 += cpLen0;
+        ++pos.character;
         continue;
 
-    lc:
-        fragment->bLast = ptr - fragment->bFirst >= x ? ptr - x : M3C_NULL;
+    cut:
+        /* NOTE: params - nextFragmentPtr, fragment->bLast */
 
-        if (ptr == document->bLast)
-            break; /* EOF */
+        if (nextFragmentPtr > document->bLast)
+            break;
 
-        /* seek to the next char */
-        ++ptr;
+        if (M3C_VEC_PUSH(M3C_ASM_Fragment, &vec, &newFragment) != M3C_ERROR_OK)
+            return M3C_ERROR_OOM;
+        fragment = &vec.data[vec.len - 1];
+
         ++pos.line;
         pos.character = 0;
 
-        /* init newFragment */
-        newFragment.bFirst = ptr;
-        newFragment.bLast = document->bLast;
-        newFragment.pos = pos;
+        fragment->bFirst = nextFragmentPtr;
+        fragment->bLast = document->bLast;
+        fragment->pos = pos;
 
-        /* push to the vector */
-        if (M3C_VEC_PUSH(M3C_ASM_Fragment, &vec, &newFragment) != M3C_ERROR_OK)
-            return M3C_ERROR_OOM;
+        ptr0 = nextFragmentPtr;
+        continue;
     }
-
-    /* LATER: shrink the vec? */
 
     /* fill the fragment cache */
     document->fragments.data = vec.data;

--- a/src/common/utf8.c
+++ b/src/common/utf8.c
@@ -233,6 +233,34 @@ M3C_UTF8ReadCodepointWithLen(const m3c_u8 *ptr, const m3c_u8 *last, M3C_UCP *cp,
 }
 
 M3C_ERROR
+M3C_UTF8ReadBackCodepointWithLen(
+    const m3c_u8 *ptr, const m3c_u8 *first, const m3c_u8 *last, M3C_UCP *cp, m3c_size_t *len
+) {
+    M3C_ERROR status;
+    const m3c_u8 *bPtr;
+    const m3c_u8 *fPtr = ptr - first > 3 ? ptr - M3C_UTF8_CP_MAX_BLEN : first;
+
+    if (fPtr == ptr) {
+        return M3C_ERROR_EOF;
+    }
+
+    do {
+        bPtr = fPtr;
+
+        status = M3C_UTF8ReadCodepointWithLen(bPtr, last, cp, len);
+        if (status == M3C_ERROR_EOF)
+            return M3C_ERROR_EOF;
+
+        fPtr += *len;
+
+    } while (fPtr < ptr);
+
+    *len = ptr - bPtr;
+
+    return status;
+}
+
+M3C_ERROR
 M3C_UTF8WriteCodepointWithLen(m3c_u8 *ptr, const m3c_u8 *last, M3C_UCP cp, m3c_size_t *len) {
 
     if (last < ptr)


### PR DESCRIPTION
## From doc:

In this phase we split a document into fragments. For example, a document containing a sequence of characters `"0\\\r\n1\r\n2\\"` will be split into the following fragments:
| is PP used | 0 | 1 | 2 |
|--------|--------|--------|--------|
| No | `"0\\\r\n"` | `"1\r\n"` | `"2\\"` |
| Yes | `"0"` | `"1\r\n"` | `"2\\"` |

In other words, each fragment corresponds to a physical line, except when the preprocessor is used and the physical line ends with the line continuation sequence, in which case the end of the fragment containing this line continuation sequence is truncated.