### PR TITLE
[M3C-73][common] impl VEC_RESERVE_UNUSED

### DIFF
--- a/include/m3c/common/coltypes.h
+++ b/include/m3c/common/coltypes.h
@@ -91,7 +91,7 @@ M3C_VEC_Push_impl(
 );
 
 /**
- * \brief Increase the capacity of the vector to a value that's greater or equal to `newCap`.
+ * \brief Increase the capacity of the vector to a value that's equal to `newCap`.
  *
  * \param[in,out] buf      pointer to the pointer to the buffer
  * \param[in,out] cap      pointer to the buffer capacity
@@ -103,7 +103,7 @@ M3C_VEC_Push_impl(
  * + #M3C_ERROR_OOM - if failed to realloc
  */
 M3C_ERROR
-M3C_VEC_Reserve_impl(void **buf, m3c_size_t *cap, m3c_size_t elemSize, m3c_size_t newCap);
+M3C_VEC_ReserveExact_impl(void **buf, m3c_size_t *cap, m3c_size_t elemSize, m3c_size_t newCap);
 
 /**
  * \brief Binary searches the array.
@@ -155,7 +155,7 @@ M3C_ERROR M3C_ARR_BSearch_impl(
     M3C_VEC_Push_impl((void **)&(VEC)->data, &(VEC)->len, &(VEC)->cap, ELEM, sizeof(TYPE))
 
 /**
- * \brief Increase the capacity of `VEC` to a value that's greater or equal to `NEW_CAP`.
+ * \brief Increase the capacity of `VEC` to a value that's equal to `NEW_CAP`.
  *
  * \param         TYPE    type of vector element
  * \param[in,out] VEC     pointer to the vector struct
@@ -165,8 +165,8 @@ M3C_ERROR M3C_ARR_BSearch_impl(
  * + #M3C_ERROR_OOB - if `sizeof(TYPE) * NEW_CAP` will overflow.
  * + #M3C_ERROR_OOM - if failed to realloc
  */
-#define M3C_VEC_RESERVE(TYPE, VEC, NEW_CAP)                                                        \
-    M3C_VEC_Reserve_impl((void **)&(VEC)->data, &(VEC)->cap, sizeof(TYPE), (NEW_CAP))
+#define M3C_VEC_RESERVE_EXACT(TYPE, VEC, NEW_CAP)                                                  \
+    M3C_VEC_ReserveExact_impl((void **)&(VEC)->data, &(VEC)->cap, sizeof(TYPE), (NEW_CAP))
 
 /**
  * \brief Binary searches the array.

--- a/include/m3c/common/coltypes.h
+++ b/include/m3c/common/coltypes.h
@@ -82,8 +82,9 @@ void const *M3C_EchoFn(void const *obj, void const *arg);
  * \param[in]     elem     pointer to the element to be pushed
  * \param         elemSize size of element in bytes
  * \return
- * + M3C_ERROR_OK
- * + M3C_ERROR_OOM - if failed to realloc
+ * + #M3C_ERROR_OK
+ * + #M3C_ERROR_OOB
+ * + #M3C_ERROR_OOM - if failed to realloc
  */
 M3C_ERROR
 M3C_VEC_Push_impl(
@@ -104,6 +105,23 @@ M3C_VEC_Push_impl(
  */
 M3C_ERROR
 M3C_VEC_ReserveExact_impl(void **buf, m3c_size_t *cap, m3c_size_t elemSize, m3c_size_t newCap);
+
+/**
+ * \brief Increases the capacity of the vector so that it can hold at least `n` new elements.
+ *
+ * \param[in,out] buf      pointer to the pointer to the buffer
+ * \param[in]     len      pointer to the buffer length
+ * \param[in,out] cap      pointer to the buffer capacity
+ * \param         elemSize size of the vector element in bytes
+ * \param         n        number of new elements
+ * \return
+ * + #M3C_ERROR_OK
+ * + #M3C_ERROR_OOB
+ * + #M3C_ERROR_OOM - if failed to realloc
+ */
+M3C_ERROR M3C_VEC_ReserveUnused_impl(
+    void **buf, m3c_size_t const *len, m3c_size_t *cap, m3c_size_t elemSize, m3c_size_t n
+);
 
 /**
  * \brief Binary searches the array.
@@ -148,8 +166,9 @@ M3C_ERROR M3C_ARR_BSearch_impl(
  * \param[in]     ELEM pointer to the element to be pushed
  *
  * \return
- * + M3C_ERROR_OK
- * + M3C_ERROR_OOM - if failed to realloc
+ * + #M3C_ERROR_OK
+ * + #M3C_ERROR_OOB
+ * + #M3C_ERROR_OOM - if failed to realloc
  */
 #define M3C_VEC_PUSH(TYPE, VEC, ELEM)                                                              \
     M3C_VEC_Push_impl((void **)&(VEC)->data, &(VEC)->len, &(VEC)->cap, ELEM, sizeof(TYPE))
@@ -167,6 +186,20 @@ M3C_ERROR M3C_ARR_BSearch_impl(
  */
 #define M3C_VEC_RESERVE_EXACT(TYPE, VEC, NEW_CAP)                                                  \
     M3C_VEC_ReserveExact_impl((void **)&(VEC)->data, &(VEC)->cap, sizeof(TYPE), (NEW_CAP))
+
+/**
+ * \brief Increases the capacity of the vector so that it can hold at least `N` new elements.
+ *
+ * \param         TYPE    type of vector element
+ * \param[in,out] VEC     pointer to the vector struct
+ * \param         N       number of new elements
+ * \return
+ * + #M3C_ERROR_OK
+ * + #M3C_ERROR_OOB
+ * + #M3C_ERROR_OOM - if failed to realloc
+ */
+#define M3C_VEC_RESERVE_UNUSED(TYPE, VEC, N)                                                       \
+    M3C_VEC_ReserveUnused_impl((void **)&(VEC)->data, &(VEC)->len, &(VEC)->cap, sizeof(TYPE), (N))
 
 /**
  * \brief Binary searches the array.

--- a/include/m3c/common/coltypes.h
+++ b/include/m3c/common/coltypes.h
@@ -98,8 +98,9 @@ M3C_VEC_Push_impl(
  * \param         elemSize size of the vector element in bytes
  * \param         newCap   new capacity of the buffer, in number of elements
  * \return
- * + M3C_ERROR_OK
- * + M3C_ERROR_OOM - if failed to realloc
+ * + #M3C_ERROR_OK
+ * + #M3C_ERROR_OOB - if `elemSize * newCap` will overflow
+ * + #M3C_ERROR_OOM - if failed to realloc
  */
 M3C_ERROR
 M3C_VEC_Reserve_impl(void **buf, m3c_size_t *cap, m3c_size_t elemSize, m3c_size_t newCap);
@@ -160,8 +161,9 @@ M3C_ERROR M3C_ARR_BSearch_impl(
  * \param[in,out] VEC     pointer to the vector struct
  * \param         NEW_CAP new capacity of the vector, in number of elements
  * \return
- * + M3C_ERROR_OK
- * + M3C_ERROR_OOM - if failed to realloc
+ * + #M3C_ERROR_OK
+ * + #M3C_ERROR_OOB - if `sizeof(TYPE) * NEW_CAP` will overflow.
+ * + #M3C_ERROR_OOM - if failed to realloc
  */
 #define M3C_VEC_RESERVE(TYPE, VEC, NEW_CAP)                                                        \
     M3C_VEC_Reserve_impl((void **)&(VEC)->data, &(VEC)->cap, sizeof(TYPE), (NEW_CAP))

--- a/include/m3c/common/errors.h
+++ b/include/m3c/common/errors.h
@@ -28,7 +28,11 @@ typedef enum __tagM3C_ERROR {
     /**
      * \brief Requested element is not found.
      */
-    M3C_ERROR_NOT_FOUND = 5
+    M3C_ERROR_NOT_FOUND = 5,
+    /**
+     * \brief Out Of Bounds.
+     */
+    M3C_ERROR_OOB = 6
 } M3C_ERROR;
 
 #endif /* _M3C_INCGUARD_ERRORS_H */

--- a/include/m3c/common/types.h
+++ b/include/m3c/common/types.h
@@ -96,6 +96,14 @@ typedef signed long long m3c_i32;
 #    ifndef FORBIT_USE_OF_STDTYPES
 #        include <stddef.h>
 typedef size_t m3c_size_t;
+#        ifndef M3C_SIZE_MAX
+#            if __STDC_VERSION__ >= 199901L
+#                include <stdint.h>
+#                define M3C_SIZE_MAX SIZE_MAX
+#            else
+#                error "M3C_SIZE_MAX is not manually defined and there is no SIZE_MAX before C99"
+#            endif
+#        endif
 #    else
 #        error "m3c_size_t is not defined and FORBIT_TO_USE_STDTYPES is defined"
 #    endif

--- a/src/asm/lex.c
+++ b/src/asm/lex.c
@@ -1212,7 +1212,7 @@ M3C_ERROR __M3C_ASM_lexemizeString(M3C_ASM_Lexer *lexer) {
                     } else
                         cp = d1;
 
-                    if (M3C_VEC_RESERVE(m3c_u8, &vec, vec.len + 1) != M3C_ERROR_OK) {
+                    if (M3C_VEC_RESERVE_EXACT(m3c_u8, &vec, vec.len + 1) != M3C_ERROR_OK) {
                         m3c_free(vec.data);
                         return M3C_ERROR_OOM;
                     }
@@ -1224,7 +1224,7 @@ M3C_ERROR __M3C_ASM_lexemizeString(M3C_ASM_Lexer *lexer) {
             }
         }
 
-        if (M3C_VEC_RESERVE(m3c_u8, &vec, vec.len + 4) != M3C_ERROR_OK) {
+        if (M3C_VEC_RESERVE_EXACT(m3c_u8, &vec, vec.len + 4) != M3C_ERROR_OK) {
             m3c_free(vec.data);
             return M3C_ERROR_OOM;
         }

--- a/src/common/coltypes.c
+++ b/src/common/coltypes.c
@@ -27,11 +27,19 @@ M3C_VEC_Push_impl(
 M3C_ERROR
 M3C_VEC_Reserve_impl(void **buf, m3c_size_t *cap, m3c_size_t elemSize, m3c_size_t newCap) {
     void *newPtr;
+    m3c_size_t byteCap; /* capacity in bytes */
 
     if (*cap >= newCap)
         return M3C_ERROR_OK;
 
-    newPtr = m3c_realloc(*buf, elemSize * newCap);
+    /* NOTE: checking overflow of `newCap * elemSize`.
+     * The code is from https://stackoverflow.com/a/1815371 */
+    byteCap = newCap * elemSize;
+    if (newCap != 0 && byteCap / newCap != elemSize) {
+        return M3C_ERROR_OOB;
+    }
+
+    newPtr = m3c_realloc(*buf, byteCap);
     if (!newPtr)
         return M3C_ERROR_OOM;
     *buf = newPtr;

--- a/src/common/coltypes.c
+++ b/src/common/coltypes.c
@@ -15,7 +15,7 @@ M3C_VEC_Push_impl(
     if (*len == *cap) {
         newCap = *cap == 0 ? 1 : *cap + *cap;
 
-        if (M3C_VEC_Reserve_impl(buf, cap, elemSize, newCap) == M3C_ERROR_OOM)
+        if (M3C_VEC_ReserveExact_impl(buf, cap, elemSize, newCap) == M3C_ERROR_OOM)
             return M3C_ERROR_OOM;
     }
 
@@ -25,7 +25,7 @@ M3C_VEC_Push_impl(
 }
 
 M3C_ERROR
-M3C_VEC_Reserve_impl(void **buf, m3c_size_t *cap, m3c_size_t elemSize, m3c_size_t newCap) {
+M3C_VEC_ReserveExact_impl(void **buf, m3c_size_t *cap, m3c_size_t elemSize, m3c_size_t newCap) {
     void *newPtr;
     m3c_size_t byteCap; /* capacity in bytes */
 


### PR DESCRIPTION
Adding `VEC_RESERVE_UNUSED` which can increase the capacity of the vector and adding some overflow  checks