### PR TITLE
[M3C-75][asm.lex] drop token.ptr

### DIFF
--- a/include/m3c/asm/lex.h
+++ b/include/m3c/asm/lex.h
@@ -225,13 +225,6 @@ typedef union __tagM3C_ASM_Lexeme {
  */
 struct __tagM3C_ASM_Token {
     /**
-     * \brief Pointer to the first byte of the token.
-     *
-     * \note Pointer to the file buffer is used, as the following stages will require access to the
-     * token bytes.
-     */
-    m3c_u8 const *ptr;
-    /**
      * \brief Parsed lexeme of the token.
      *
      * \warning Only tokens of the following types have their own lexemes:

--- a/src/asm/lex.c
+++ b/src/asm/lex.c
@@ -74,7 +74,6 @@
  * \details The lexer must point to the first character of the token.
  */
 #define TOK_START                                                                                  \
-    lexer->token.ptr = lexer->ptr;                                                                 \
     lexer->token.start = lexer->pos;                                                               \
     lexer->token.lexeme.hStr = 0;                                                                  \
     /* save info for token rereading */                                                            \


### PR DESCRIPTION
We don't need `M3C_ASM_Token::ptr` as:
1. the token already stores information about the position of the first and the next character after the token (`start` and `end` respectively), so we can use `M3C_ASM_Document::fragments` to find the first byte of the line, and then read the document char by char (remember that one must use the same encoding) to find the first byte of the token
2. `ptr` has no meaning (as well as positions) for pre-processor-generated tokens