### PR TITLE
[M3C-74][asm.lex] make diagnostics correspond to tokens

### DIFF
--- a/include/m3c/asm/diagnostics.h
+++ b/include/m3c/asm/diagnostics.h
@@ -143,6 +143,10 @@ typedef enum __tagM3C_ASM_DiagnosticId {
  */
 typedef struct __tagM3C_ASM_DiagnosticsData {
     /**
+     * \brief Handle of the nearest token starting before the diagnostic starts.
+     */
+    M3C_ASM_hToken hToken;
+    /**
      * \brief Start position.
      */
     M3C_ASM_Position start;
@@ -150,10 +154,6 @@ typedef struct __tagM3C_ASM_DiagnosticsData {
      * \brief End position (exclusive).
      */
     M3C_ASM_Position end;
-    /**
-     * \brief Handle of include information.
-     */
-    M3C_hINCLUDE hInclude;
 } M3C_ASM_DiagnosticsData;
 
 #endif /* _M3C_INCGUARD_ASM_DIAGNOSTICS_H */

--- a/include/m3c/asm/preproc.h
+++ b/include/m3c/asm/preproc.h
@@ -170,22 +170,31 @@ struct __tagM3C_ASM_Document {
     /**
      * \brief Lexer diagnostics.
      *
-     * \details Possible diagnostics:
+     * \details \ref M3C_ASM_DiagnosticsData::hToken "DiagnosticsData::hToken" of all diagnostics
+     * must correspond to the index of token in \ref M3C_ASM_Document::tokens "Document::tokens".
+     *
+     * Possible diagnostics:
      * + \ref M3C_ASM_DIAGNOSTIC_ID_INVALID_ENCODING "INVALID_ENCODING"
      * + \ref M3C_ASM_DIAGNOSTIC_ID_UNRECOGNIZED_TOKEN "UNRECOGNIZED_TOKEN"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_LEADING_ZEROS_ARE_NOT_PERMITTED
+     * "LEADING_ZEROS_ARE_NOT_PERMITTED"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_INVALID_BASE_PREFIX "INVALID_BASE_PREFIX"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_DIGIT_SEPARATOR_CANNOT_APPEAR_HERE
+     * "DIGIT_SEPARATOR_CANNOT_APPEAR_HERE"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_NUMBER_LITERAL_MUST_CONTAIN_AT_LEAST_ONE_DIGIT
+     * "NUMBER_LITERAL_MUST_CONTAIN_AT_LEAST_ONE_DIGIT"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_INVALID_DIGIT_FOR_THIS_BASE_PREFIX
+     * "INVALID_DIGIT_FOR_THIS_BASE_PREFIX"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_UNTERMINATED_STRING_LITERAL "UNTERMINATED_STRING_LITERAL"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_UNKNOWN_ESCAPE_SEQUENCE "UNKNOWN_ESCAPE_SEQUENCE"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_X_USED_WITH_NO_FOLLOWING_HEX_DIGITS
+     * "X_USED_WITH_NO_FOLLOWING_HEX_DIGITS"
+     * + \ref M3C_ASM_DIAGNOSTIC_ID_NUMBER_CONSTANT_IS_TOO_LARGE "NUMBER_CONSTANT_IS_TOO_LARGE"
      *
      * \note The diagnostics will be the same for the same document. There is no need to calculate
      * them each time the same document is included.
      */
     M3C_Diagnostics diagnostics;
-    /**
-     * \brief Handle of the include information (by which the document was included for the
-     * **first** time).
-     *
-     * \note The same document can be included many times from different documents (and even
-     * explicitly by the user itself as an entry document).
-     */
-    M3C_hINCLUDE hInclude;
 };
 
 /**

--- a/include/m3c/asm/types.h
+++ b/include/m3c/asm/types.h
@@ -17,9 +17,11 @@ typedef M3C_VEC(M3C_ASM_Token) M3C_ASM_Tokens;
  **************************************************************************************************/
 
 /**
- * \brief Handle of include information.
+ * \brief Handle of specific token.
+ *
+ * \details Corresponds to the index of the token in #M3C_ASM_Document::tokens.
  */
-typedef m3c_u16 M3C_hINCLUDE;
+typedef m3c_u32 M3C_ASM_hToken;
 
 typedef struct __tagM3C_ASM_Document M3C_ASM_Document;
 

--- a/src/asm/lex.c
+++ b/src/asm/lex.c
@@ -115,13 +115,13 @@
  */
 #define DIAG_START_FROM_LEXER(diag)                                                                \
     (diag)->data.ASM.start = lexer->pos;                                                           \
-    (diag)->data.ASM.hInclude = lexer->hInclude
+    (diag)->data.ASM.hToken = lexer->tokens->len
 /**
  * \brief Sets the diagnostic start position from the token start position.
  */
 #define DIAG_START_FROM_TOKEN(diag)                                                                \
     (diag)->data.ASM.start = lexer->token.start;                                                   \
-    (diag)->data.ASM.hInclude = lexer->hInclude
+    (diag)->data.ASM.hToken = lexer->tokens->len
 /**
  * \brief Sets the end position of the diagnostic.
  *
@@ -273,7 +273,6 @@ typedef struct __tagM3C_ASM_Lexer {
      * \brief Fragment, where the actual token has started.
      */
     M3C_ASM_Fragment *fragment2;
-    M3C_hINCLUDE hInclude;
     /**
      * \brief Preproc's stringPool.
      */
@@ -1618,7 +1617,6 @@ M3C_ERROR M3C_ASM_lex(M3C_ASM_PreProc *preproc, m3c_u32 hDocument) {
 
     lexer.diagnostics = &document->diagnostics;
     lexer.tokens = &document->tokens;
-    lexer.hInclude = document->hInclude;
 
     M3C_LOOP {
         res = __M3C_ASM_lexNextToken(&lexer);


### PR DESCRIPTION
It seems that storing a token handler in each diagnostic is easier than include information. Diagnostics can refer to tokens that appeared as a result of the preprocessor work. 