### PR TITLE
[M3C-90][rt] add M3C_FEATURE_USE_COMPILER_BUILTIN_FUNCTIONS feature

### DIFF
--- a/include/m3c/common/babel.h
+++ b/include/m3c/common/babel.h
@@ -1,13 +1,15 @@
 #ifndef _M3C_INCGUARD_BABEL_H
 #define _M3C_INCGUARD_BABEL_H
 
+#include <m3c/common/env.h>
+
 #if __STDC_VERSION__ >= 199901L
 #    define m3c_restrict restrict
 #else
 #    define m3c_restrict /* just ignore before C99 */
 #endif
 
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(M3C_GNUC) || defined(M3C_CLANG)
 #    define M3C_SYSV_ABI __attribute__((sysv_abi))
 #endif
 

--- a/include/m3c/common/env.h
+++ b/include/m3c/common/env.h
@@ -10,6 +10,12 @@
  * <a href="https://sourceforge.net/projects/predef/">Pre-defined Compiler Macros</a> project.
  */
 
+#ifdef __clang__
+#    define M3C_CLANG 1
+#elif defined(__GNUC__)
+#    define M3C_GNUC 1
+#endif
+
 #if defined(__linux__) || defined(__linux) || defined(linux)
 #    define M3C_KERNEL_LINUX 1
 #endif

--- a/include/m3c/rt/mem.h
+++ b/include/m3c/rt/mem.h
@@ -1,14 +1,25 @@
 #ifndef _M3C_INCGUARD_RT_MEM_H
 #define _M3C_INCGUARD_RT_MEM_H
 
+#include <m3c/common/env.h>
 #include <m3c/common/types.h>
 #include <m3c/common/babel.h>
 
-#include <string.h>
+#ifdef M3C_FEATURE_USE_COMPILER_BUILTIN_FUNCTIONS
 
-#define m3c_memcpy(dest, src, count) memcpy(dest, src, count)
+#    if defined(M3C_GNUC) || defined(M3C_CLANG)
 
-#define m3c_memmove(dest, src, count) memmove(dest, src, count)
+/* See:
+ * + https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
+ * + https://clang.llvm.org/docs/LanguageExtensions.html#builtin-functions
+ */
+
+#        define m3c_memcpy(dest, src, count) __builtin_memcpy(dest, src, count)
+#        define m3c_memmove(dest, src, count) __builtin_memmove(dest, src, count)
+
+#    endif /* M3C_GNUC || M3C_CLANG */
+
+#endif /* M3C_FEATURE_USE_COMPILER_BUILTIN_FUNCTIONS */
 
 /**
  * \brief Fills `dest` with the contents of `src`. The specified `len` and `count` parameters


### PR DESCRIPTION
In the future, I plan to write my own "builtin" functions and let the user use them. Also, this feature is useful if the user wants to use his own "builtin" functions